### PR TITLE
Bugfix: Mesh update memory leak

### DIFF
--- a/Assets/Plugins/VRSketchingGeometry/Scripts/Interaction/PatchSketchObject.cs
+++ b/Assets/Plugins/VRSketchingGeometry/Scripts/Interaction/PatchSketchObject.cs
@@ -43,7 +43,7 @@ namespace VRSketchingGeometry.SketchObjectManagement
         }
 
         private void SetMesh(Mesh mesh) {
-            UpdateRenderedMesh(mesh);
+            UpdateSceneMesh(mesh);
         }
 
         /// <summary>

--- a/Assets/Plugins/VRSketchingGeometry/Scripts/Interaction/PatchSketchObject.cs
+++ b/Assets/Plugins/VRSketchingGeometry/Scripts/Interaction/PatchSketchObject.cs
@@ -43,10 +43,7 @@ namespace VRSketchingGeometry.SketchObjectManagement
         }
 
         private void SetMesh(Mesh mesh) {
-            Mesh oldMesh = this.GetComponent<MeshFilter>().sharedMesh;
-            Destroy(oldMesh);
-            this.GetComponent<MeshFilter>().sharedMesh = mesh;
-            this.GetComponent<MeshCollider>().sharedMesh = mesh;
+            UpdateRenderedMesh(mesh);
         }
 
         /// <summary>

--- a/Assets/Plugins/VRSketchingGeometry/Scripts/Interaction/RibbonSketchObject.cs
+++ b/Assets/Plugins/VRSketchingGeometry/Scripts/Interaction/RibbonSketchObject.cs
@@ -28,7 +28,7 @@ namespace VRSketchingGeometry.SketchObjectManagement{
 
         private void UpdateMesh(Mesh mesh)
         {
-            UpdateRenderedMesh(mesh);
+            UpdateSceneMesh(mesh);
         }
 
         /// <summary>

--- a/Assets/Plugins/VRSketchingGeometry/Scripts/Interaction/RibbonSketchObject.cs
+++ b/Assets/Plugins/VRSketchingGeometry/Scripts/Interaction/RibbonSketchObject.cs
@@ -13,16 +13,6 @@ namespace VRSketchingGeometry.SketchObjectManagement{
     [RequireComponent(typeof(MeshFilter), typeof(MeshRenderer), typeof(MeshCollider))]
     public class RibbonSketchObject : SketchObject, ISerializableComponent, IBrushable
     {
-        /// <summary>
-        /// Mesh filter for the mesh of the ribbon
-        /// </summary>
-        protected MeshFilter meshFilter;
-
-        /// <summary>
-        /// Collider for the mesh of the ribbon
-        /// </summary>
-        protected MeshCollider meshCollider;
-
         private RibbonMesh RibbonMesh;
 
         private List<Vector3> Points = new List<Vector3>();
@@ -32,16 +22,13 @@ namespace VRSketchingGeometry.SketchObjectManagement{
         protected override void Awake()
         {
             base.Awake();
-            meshFilter = GetComponent<MeshFilter>();
-            meshCollider = GetComponent<MeshCollider>();
 
             RibbonMesh = new RibbonMesh(Vector3.one * .3f);
         }
 
         private void UpdateMesh(Mesh mesh)
         {
-            meshFilter.sharedMesh = mesh;
-            meshCollider.sharedMesh = mesh;
+            UpdateRenderedMesh(mesh);
         }
 
         /// <summary>

--- a/Assets/Plugins/VRSketchingGeometry/Scripts/Interaction/SketchObject.cs
+++ b/Assets/Plugins/VRSketchingGeometry/Scripts/Interaction/SketchObject.cs
@@ -51,7 +51,12 @@ namespace VRSketchingGeometry.SketchObjectManagement {
             meshRenderer.sharedMaterial = originalMaterial;
         }
 
-        protected virtual void UpdateRenderedMesh(Mesh newMesh) {
+        /// <summary>
+        /// Replace both the renderer and collider mesh with a new one.
+        /// The old mesh is manually destroyed to prevent a memory leak.
+        /// </summary>
+        /// <param name="newMesh">The new mesh to replace the old one.</param>
+        protected virtual void UpdateSceneMesh(Mesh newMesh) {
             Mesh oldMesh = meshFilter.sharedMesh;
             meshFilter.sharedMesh = newMesh;
             meshCollider.sharedMesh = newMesh;

--- a/Assets/Plugins/VRSketchingGeometry/Scripts/Interaction/SketchObject.cs
+++ b/Assets/Plugins/VRSketchingGeometry/Scripts/Interaction/SketchObject.cs
@@ -16,6 +16,8 @@ namespace VRSketchingGeometry.SketchObjectManagement {
         public override SketchObjectGroup ParentGroup { get => parentGroup; set => parentGroup = value; }
 
         protected MeshRenderer meshRenderer;
+        protected MeshFilter meshFilter;
+        protected MeshCollider meshCollider;
 
         protected Material originalMaterial;
 
@@ -33,6 +35,8 @@ namespace VRSketchingGeometry.SketchObjectManagement {
 
         protected void setUpOriginalMaterialAndMeshRenderer()
         {
+            meshFilter = GetComponent<MeshFilter>();
+            meshCollider = GetComponent<MeshCollider>();
             meshRenderer = GetComponent<MeshRenderer>();
             originalMaterial = meshRenderer.sharedMaterial;
         }
@@ -45,6 +49,19 @@ namespace VRSketchingGeometry.SketchObjectManagement {
         public override void revertHighlight()
         {
             meshRenderer.sharedMaterial = originalMaterial;
+        }
+
+        protected virtual void UpdateRenderedMesh(Mesh newMesh) {
+            Mesh oldMesh = meshFilter.sharedMesh;
+            meshFilter.sharedMesh = newMesh;
+            meshCollider.sharedMesh = newMesh;
+            if (Application.isEditor && !Application.isPlaying)
+            {
+                DestroyImmediate(oldMesh);
+            }
+            else{
+                Destroy(oldMesh);
+            }
         }
     }
 }


### PR DESCRIPTION
An issue with the assignment of updated meshes to the mesh filter has been fixed. The old meshes are now always explicitly destroyed before assigning the new mesh.

Read more about this issue here: https://nothkedev.blogspot.com/2018/08/procedurally-generated-meshes-in-unity.html